### PR TITLE
feat: Create initial Huebris theme showcase page

### DIFF
--- a/docs/assets/.placeholder
+++ b/docs/assets/.placeholder
@@ -1,0 +1,2 @@
+# This is a placeholder file to ensure the docs/assets directory is created.
+# It can be removed later.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,277 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Huebris Theme Showcase</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <h1>Huebris Theme Showcase</h1>
+    </header>
+
+    <section id="welcome">
+        <h2>Welcome to the Huebris Theme!</h2>
+        <p>This page showcases the features and appearance of the Huebris Theme.</p>
+    </section>
+
+    <section id="theme-colors">
+        <h2>Theme Colors</h2>
+
+        <h3>Light Mode Colors</h3>
+        <div class="color-swatch-container">
+            <div class="color-swatch" style="background-color: #FFFFFF;"><span>#FFFFFF<br>Editor BG</span></div>
+            <div class="color-swatch" style="background-color: #333333;"><span>#333333<br>Default Text</span></div>
+            <div class="color-swatch" style="background-color: #F5F5F5;"><span>#F5F5F5<br>Activity Bar BG</span></div>
+            <div class="color-swatch" style="background-color: #F5F5F5;"><span>#F5F5F5<br>Side Bar BG</span></div>
+            <div class="color-swatch" style="background-color: #007ACC;"><span>#007ACC<br>Status Bar BG</span></div>
+            <div class="color-swatch" style="background-color: #007ACC;"><span>#007ACC<br>Button BG</span></div>
+            <div class="color-swatch" style="background-color: #FFFFFF;"><span>#FFFFFF<br>Input BG</span></div>
+            <div class="color-swatch" style="background-color: #007ACC;"><span>#007ACC<br>Focus Border</span></div>
+            <div class="color-swatch" style="background-color: #EEEEEE;"><span>#EEEEEE<br>Line Highlight</span></div>
+            <div class="color-swatch" style="background-color: #ADD6FF;"><span>#ADD6FF<br>Selection BG</span></div>
+            <div class="color-swatch" style="background-color: #6A737D;"><span>#6A737D<br>Comment</span></div>
+            <div class="color-swatch" style="background-color: #005CC5;"><span>#005CC5<br>Keyword</span></div>
+            <div class="color-swatch" style="background-color: #D73A49;"><span>#D73A49<br>String</span></div>
+            <div class="color-swatch" style="background-color: #6F42C1;"><span>#6F42C1<br>Variable</span></div>
+            <div class="color-swatch" style="background-color: #E36209;"><span>#E36209<br>Number</span></div>
+        </div>
+
+        <h3>Dark Mode Colors</h3>
+        <div class="color-swatch-container">
+            <div class="color-swatch" style="background-color: #202432;"><span>#202432<br>Editor BG</span></div>
+            <div class="color-swatch" style="background-color: #d3d0c8;"><span>#d3d0c8<br>Default Text</span></div>
+            <div class="color-swatch" style="background-color: #181b25;"><span>#181b25<br>Activity Bar BG</span></div>
+            <div class="color-swatch" style="background-color: #1c1f2b;"><span>#1c1f2b<br>Side Bar BG</span></div>
+            <div class="color-swatch" style="background-color: #001432;"><span>#001432<br>Status Bar BG</span></div>
+            <div class="color-swatch" style="background-color: #002daa;"><span>#002daa<br>Button BG</span></div>
+            <div class="color-swatch" style="background-color: #202432;"><span>#202432<br>Input BG</span></div>
+            <div class="color-swatch" style="background-color: #165fb3;"><span>#165fb3<br>Focus Border</span></div>
+            <div class="color-swatch" style="background-color: #ffffff33;"><span>#ffffff33<br>Line Highlight</span></div>
+            <div class="color-swatch" style="background-color: #00000055;"><span>#00000055<br>Selection BG</span></div>
+            <div class="color-swatch" style="background-color: #747369;"><span>#747369<br>Comment</span></div>
+            <div class="color-swatch" style="background-color: #22A8CD;"><span>#22A8CD<br>Keyword</span></div>
+            <div class="color-swatch" style="background-color: #FE5C7B;"><span>#FE5C7B<br>String</span></div>
+            <div class="color-swatch" style="background-color: #A97BFF;"><span>#A97BFF<br>Variable</span></div>
+            <div class="color-swatch" style="background-color: #F99157;"><span>#F99157<br>Number</span></div>
+        </div>
+    </section>
+
+    <section id="typography">
+        <h2>Typography</h2>
+        <p>Huebris theme uses standard system fonts for UI elements and a common monospace font for the editor. Ensure your VSCode is configured to use your preferred coding font.</p>
+        <div class="font-example">
+            <h4>Example Heading 4</h4>
+            <p>This is an example paragraph. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.</p>
+        </div>
+    </section>
+
+    <section id="design-elements">
+        <h2>Key Design Elements</h2>
+        <p>Huebris provides distinct styling for:</p>
+        <ul>
+            <li>Editor Background &amp; Foreground</li>
+            <li>Selection Highlights</li>
+            <li>Active Line Highlighting</li>
+            <li>Activity Bar, Status Bar, and Side Bar</li>
+            <li>Tabs (Active and Inactive)</li>
+            <li>UI Borders (Focus, Input, etc.)</li>
+            <li>Syntax tokens: Keywords, Strings, Comments, Variables, Functions, Numbers, Tags.</li>
+        </ul>
+    </section>
+
+    <section id="vscode-examples">
+        <h2>VSCode Examples</h2>
+        <div class="screenshot-group">
+            <div class="screenshot-container light-mode-screenshot">
+                <h3>Editor (Light Mode)</h3>
+                <img src="assets/vscode-editor-light.png" alt="VSCode Editor - Huebris Light Theme">
+                <h3>Explorer (Light Mode)</h3>
+                <img src="assets/vscode-explorer-light.png" alt="VSCode Explorer - Huebris Light Theme">
+            </div>
+            <div class="screenshot-container dark-mode-screenshot" style="display:none;">
+                <h3>Editor (Dark Mode)</h3>
+                <img src="assets/vscode-editor-dark.png" alt="VSCode Editor - Huebris Dark Theme">
+                <h3>Explorer (Dark Mode)</h3>
+                <img src="assets/vscode-explorer-dark.png" alt="VSCode Explorer - Huebris Dark Theme">
+            </div>
+        </div>
+    </section>
+
+    <section id="syntax-highlighting">
+        <h2>Code Syntax Highlighting</h2>
+        <div class="code-example-container">
+            <h3>JavaScript</h3>
+            <pre><code class="language-javascript">/*
+ * Simple JavaScript Example
+ */
+function greet(name) {
+  // Using a template literal
+  const message = `Hello, ${name}!`;
+  console.log(message);
+  return message;
+}
+
+let person = "Huebris User";
+greet(person); // Output: Hello, Huebris User!
+
+// Example of a loop
+for (let i = 0; i < 3; i++) {
+  console.log(`Iteration ${i}`);
+}
+
+// Arrow function
+const add = (a, b) => a + b;
+console.log(`2 + 3 = ${add(2, 3)}`);</code></pre>
+            <h3>Python</h3>
+            <pre><code class="language-python"># Simple Python Example
+class Greeter:
+    def __init__(self, name):
+        self.name = name  # Instance variable
+
+    def greet(self, loud=False):
+        if loud:
+            print(f'HELLO, {self.name.upper()}!')
+        else:
+            print(f'Hello, {self.name}')
+
+# Create an instance
+g = Greeter("Huebris Coder")
+g.greet()
+g.greet(loud=True)
+
+# List comprehension
+numbers = [x * x for x in range(1, 6)] # [1, 4, 9, 16, 25]
+print(numbers)</code></pre>
+            <h3>Java</h3>
+            <pre><code class="language-java">/**
+ * Simple Java Example
+ */
+public class Greeter {
+    private String name; // Instance variable
+
+    public Greeter(String name) {
+        this.name = name;
+    }
+
+    public void greet() {
+        System.out.println("Hello, " + this.name + "!");
+    }
+
+    public static void main(String[] args) {
+        Greeter greeter = new Greeter("Huebris Developer");
+        greeter.greet(); // Output: Hello, Huebris Developer!
+
+        // Example of a loop
+        for (int i = 0; i < 3; i++) {
+            System.out.println("Iteration: " + i);
+        }
+    }
+}</code></pre>
+            <h3>C++</h3>
+            <pre><code class="language-cpp">// Simple C++ Example
+#include &lt;iostream&gt;
+#include &lt;string&gt;
+#include &lt;vector&gt;
+
+class Greeter {
+public:
+    Greeter(std::string name) : name(name) {}
+
+    void greet() {
+        std::cout &lt;&lt; "Hello, " &lt;&lt; name &lt;&lt; "!" &lt;&lt; std::endl;
+    }
+private:
+    std::string name;
+};
+
+int main() {
+    Greeter greeter("Huebris Programmer");
+    greeter.greet();
+
+    std::vector&lt;int&gt; numbers;
+    for (int i = 1; i &lt;= 5; ++i) {
+        numbers.push_back(i * i);
+    }
+    // numbers contains {1, 4, 9, 16, 25}
+    for (int num : numbers) {
+        std::cout &lt;&lt; num &lt;&lt; " ";
+    }
+    std::cout &lt;&lt; std::endl;
+    return 0;
+}</code></pre>
+            <h3>HTML</h3>
+            <pre><code class="language-html">&lt;!DOCTYPE html&gt;
+&lt;html lang="en"&gt;
+&lt;head&gt;
+    &lt;meta charset="UTF-8"&gt;
+    &lt;meta name="viewport" content="width=device-width, initial-scale=1.0"&gt;
+    &lt;title&gt;Huebris Page&lt;/title&gt;
+    &lt;link rel="stylesheet" href="style.css"&gt;
+&lt;/head&gt;
+&lt;body&gt;
+    &lt;header&gt;
+        &lt;h1&gt;Welcome to Huebris&lt;/h1&gt;
+    &lt;/header&gt;
+
+    &lt;!-- This is an HTML comment --&gt;
+    &lt;section id="main-content"&gt;
+        &lt;p&gt;This is a paragraph with &lt;strong&gt;strong&lt;/strong&gt; text and an &lt;a href="#"&gt;example link&lt;/a&gt;.&lt;/p&gt;
+        &lt;ul&gt;
+            &lt;li&gt;List item 1&lt;/li&gt;
+            &lt;li&gt;List item 2&lt;/li&gt;
+        &lt;/ul&gt;
+    &lt;/section&gt;
+
+    &lt;script src="script.js"&gt;&lt;/script&gt;
+&lt;/body&gt;
+&lt;/html&gt;</code></pre>
+            <h3>CSS</h3>
+            <pre><code class="language-css">/* Simple CSS Example */
+body {
+    font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-color-light); /* Using CSS Variable */
+    color: var(--text-color-light);
+    line-height: 1.6;
+}
+
+header {
+    background-color: #007acc;
+    color: white;
+    padding: 1em 0;
+    text-align: center;
+}
+
+#main-content {
+    padding: 20px;
+}
+
+/* Class selector */
+.highlight {
+    background-color: yellow;
+    font-weight: bold;
+}
+
+/* ID selector */
+#footer {
+    margin-top: 30px;
+    padding: 10px;
+    border-top: 1px solid #ccc;
+}</code></pre>
+        </div>
+    </section>
+
+    <section id="toggle-mode">
+        <h2>Toggle Light/Dark Mode</h2>
+        <button id="theme-toggle-button">Toggle Mode</button> <!-- Changed ID here -->
+    </section>
+
+    <footer>
+        <p>&copy; 2023 Huebris Theme</p>
+    </footer>
+    <script src="script.js"></script>
+</body>
+</html>

--- a/docs/script.js
+++ b/docs/script.js
@@ -1,0 +1,61 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const themeToggleButton = document.getElementById('theme-toggle-button'); // Changed ID
+    const body = document.body;
+    const lightModeScreenshots = document.querySelectorAll('.light-mode-screenshot');
+    const darkModeScreenshots = document.querySelectorAll('.dark-mode-screenshot');
+
+    const showScreenshots = (theme) => {
+        if (theme === 'dark') {
+            lightModeScreenshots.forEach(el => el.style.display = 'none');
+            darkModeScreenshots.forEach(el => el.style.display = 'block');
+        } else {
+            lightModeScreenshots.forEach(el => el.style.display = 'block');
+            darkModeScreenshots.forEach(el => el.style.display = 'none');
+        }
+        // TODO: Add logic to update code example styling if necessary (though CSS variables should handle most of this)
+    };
+
+    const applyTheme = (theme) => {
+        if (theme === 'dark') {
+            body.classList.add('dark-mode');
+            themeToggleButton.textContent = 'Switch to Light Mode';
+        } else {
+            body.classList.remove('dark-mode');
+            themeToggleButton.textContent = 'Switch to Dark Mode';
+        }
+        showScreenshots(theme);
+        // Placeholder for future:
+        // updateCodeExamplesTheme(theme);
+    };
+
+    // Check localStorage for saved theme preference
+    let currentTheme = localStorage.getItem('theme');
+    if (!currentTheme) {
+        // If no theme saved, check for system preference
+        if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+            currentTheme = 'dark';
+        } else {
+            currentTheme = 'light'; // Default to light
+        }
+    }
+
+    applyTheme(currentTheme);
+
+    themeToggleButton.addEventListener('click', () => {
+        let newTheme;
+        if (body.classList.contains('dark-mode')) {
+            newTheme = 'light';
+        } else {
+            newTheme = 'dark';
+        }
+        applyTheme(newTheme);
+        localStorage.setItem('theme', newTheme);
+    });
+
+    // Listen for system theme changes
+    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', e => {
+        const newColorScheme = e.matches ? 'dark' : 'light';
+        applyTheme(newColorScheme);
+        localStorage.setItem('theme', newColorScheme);
+    });
+});

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,0 +1,246 @@
+:root {
+    --font-family-default: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+
+    /* Light Theme Variables */
+    --bg-color-light: #ffffff;
+    --text-color-light: #212529;
+    --heading-color-light: #1a1a1a;
+    --section-bg-color-light: #f8f9fa;
+    --section-border-color-light: #dee2e6;
+    --pre-bg-color-light: #e9ecef;
+    --pre-text-color-light: #212529;
+    --pre-border-color-light: #ced4da;
+    --button-bg-color-light: #007bff;
+    --button-text-color-light: #ffffff;
+    --button-hover-bg-color-light: #0056b3;
+    --link-color-light: #007bff;
+
+    /* Dark Theme Variables */
+    --bg-color-dark: #1a1a1a; /* Darker background */
+    --text-color-dark: #e0e0e0; /* Lighter text */
+    --heading-color-dark: #f5f5f5; /* Even lighter for headings */
+    --section-bg-color-dark: #2c2c2c; /* Darker section background */
+    --section-border-color-dark: #444444; /* Darker border */
+    --pre-bg-color-dark: #222222; /* Very dark for code blocks */
+    --pre-text-color-dark: #d0d0d0; /* Light gray for code text */
+    --pre-border-color-dark: #383838;
+    --button-bg-color-dark: #007bff; /* Keep button noticeable, or use a theme-specific accent */
+    --button-text-color-dark: #ffffff;
+    --button-hover-bg-color-dark: #0056b3;
+    --link-color-dark: #6cb2eb; /* Lighter blue for links */
+}
+
+body {
+    font-family: var(--font-family-default);
+    margin: 0;
+    padding: 0;
+    background-color: var(--bg-color-light);
+    color: var(--text-color-light);
+    transition: background-color 0.3s ease, color 0.3s ease;
+    padding-bottom: 60px; /* Footer height */
+}
+
+body.dark-mode {
+    background-color: var(--bg-color-dark);
+    color: var(--text-color-dark);
+}
+
+header {
+    background-color: var(--section-bg-color-light);
+    color: var(--heading-color-light);
+    padding: 1.5em 0;
+    text-align: center;
+    border-bottom: 1px solid var(--section-border-color-light);
+}
+
+body.dark-mode header {
+    background-color: var(--section-bg-color-dark);
+    color: var(--heading-color-dark);
+    border-bottom: 1px solid var(--section-border-color-dark);
+}
+
+h1, h2, h3 {
+    color: var(--heading-color-light);
+    margin-top: 1.5em;
+    margin-bottom: 0.8em;
+}
+body.dark-mode h1, body.dark-mode h2, body.dark-mode h3 {
+    color: var(--heading-color-dark);
+}
+
+h1 { font-size: 2.5em; }
+h2 { font-size: 2em; }
+h3 { font-size: 1.5em; }
+
+section {
+    padding: 1.5em;
+    margin: 1em auto; /* Center sections */
+    background-color: var(--section-bg-color-light);
+    border: 1px solid var(--section-border-color-light);
+    border-radius: 8px;
+    max-width: 960px; /* Max width for content */
+}
+
+body.dark-mode section {
+    background-color: var(--section-bg-color-dark);
+    border: 1px solid var(--section-border-color-dark);
+}
+
+/* Theme Colors Section */
+#theme-colors .color-swatch-container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1em;
+    margin-top: 1em;
+}
+
+.color-swatch {
+    width: 100px;
+    height: 100px;
+    border-radius: 4px;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    align-items: center;
+    padding: 0.5em;
+    font-size: 0.8em;
+    color: var(--text-color-light); /* Default, assuming light swatch bg */
+    border: 1px solid var(--section-border-color-light);
+}
+
+.color-swatch span {
+    background-color: rgba(255, 255, 255, 0.7); /* Light background for text on swatch */
+    padding: 0.2em 0.4em;
+    border-radius: 3px;
+}
+
+body.dark-mode .color-swatch {
+    color: var(--text-color-dark); /* Default, assuming dark swatch bg */
+    border: 1px solid var(--section-border-color-dark);
+}
+
+body.dark-mode .color-swatch span {
+     background-color: rgba(0, 0, 0, 0.5); /* Dark background for text on swatch */
+     color: var(--text-color-dark);
+}
+
+
+/* Typography Section */
+#typography .font-example {
+    margin-bottom: 1em;
+    padding: 0.5em;
+    border-left: 3px solid var(--link-color-light);
+}
+body.dark-mode #typography .font-example {
+    border-left: 3px solid var(--link-color-dark);
+}
+#typography .font-example h4 { margin-top: 0; }
+
+/* Key Design Elements Section */
+#design-elements ul {
+    list-style-type: disc;
+    padding-left: 20px;
+}
+
+/* VSCode Examples Section */
+#vscode-examples .screenshot-container {
+    margin-top: 1em;
+    text-align: center; /* Center screenshots */
+}
+#vscode-examples img {
+    max-width: 100%;
+    height: auto;
+    border: 1px solid var(--section-border-color-light);
+    border-radius: 4px;
+}
+body.dark-mode #vscode-examples img {
+    border: 1px solid var(--section-border-color-dark);
+}
+#vscode-examples figcaption {
+    font-size: 0.9em;
+    color: var(--text-color-light);
+    margin-top: 0.5em;
+}
+body.dark-mode #vscode-examples figcaption {
+    color: var(--text-color-dark);
+}
+
+/* Code Syntax Highlighting Section */
+pre {
+    background-color: var(--pre-bg-color-light);
+    color: var(--pre-text-color-light);
+    border: 1px solid var(--pre-border-color-light);
+    padding: 1em;
+    border-radius: 4px;
+    overflow-x: auto; /* For long code lines */
+    font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
+    font-size: 0.95em;
+    line-height: 1.6;
+}
+
+body.dark-mode pre {
+    background-color: var(--pre-bg-color-dark);
+    color: var(--pre-text-color-dark);
+    border: 1px solid var(--pre-border-color-dark);
+}
+
+code {
+    font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
+}
+
+/* Toggle Button */
+#mode-toggle-button {
+    padding: 0.7em 1.2em;
+    background-color: var(--button-bg-color-light);
+    color: var(--button-text-color-light);
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+    font-size: 1em;
+    transition: background-color 0.2s ease;
+}
+
+#mode-toggle-button:hover {
+    background-color: var(--button-hover-bg-color-light);
+}
+
+body.dark-mode #mode-toggle-button {
+    background-color: var(--button-bg-color-dark);
+    color: var(--button-text-color-dark);
+}
+
+body.dark-mode #mode-toggle-button:hover {
+    background-color: var(--button-hover-bg-color-dark); /* Consider a different hover for dark if needed */
+}
+
+
+/* Footer */
+footer {
+    text-align: center;
+    padding: 1em 0;
+    background-color: var(--section-bg-color-light);
+    color: var(--text-color-light);
+    border-top: 1px solid var(--section-border-color-light);
+    position: fixed;
+    bottom: 0;
+    width: 100%;
+    font-size: 0.9em;
+}
+
+body.dark-mode footer {
+    background-color: var(--section-bg-color-dark);
+    color: var(--text-color-dark);
+    border-top: 1px solid var(--section-border-color-dark);
+}
+
+/* Links */
+a {
+    color: var(--link-color-light);
+    text-decoration: none;
+}
+a:hover {
+    text-decoration: underline;
+}
+body.dark-mode a {
+    color: var(--link-color-dark);
+}


### PR DESCRIPTION
Adds a new documentation page at `docs/index.html` to showcase the Huebris theme.

The page features:
- Display of key theme colors for both light and dark modes, extracted from the theme's JSON definition.
- Sections for Typography and Key Design Elements.
- Placeholders for VSCode editor and explorer screenshots (light and dark).
- Syntax highlighting examples for JavaScript, Python, Java, C++, HTML, and CSS using generic code snippets.
- A toggle button to switch between light and dark modes.
- Theme preference persistence using localStorage and respects system color scheme preference.
- Associated CSS (`docs/style.css`) for styling and JavaScript (`docs/script.js`) for interactivity.
- An `assets` directory (`docs/assets`) for images.

This initial version provides a comprehensive overview of the Huebris theme's visual elements and behavior. Actual screenshots for VSCode examples will be added in a future update.